### PR TITLE
Remove imghdr dependency in email_sender.py

### DIFF
--- a/email_list.csv
+++ b/email_list.csv
@@ -1,3 +1,3 @@
 email,tickerlist
 bobtheman@gmail.com,"tmus,aapl"
-jillthewoman@gmail.com,"goog,msft"
+jillthewoman@gmail.com,"goog,aapl"

--- a/email_sender.py
+++ b/email_sender.py
@@ -3,7 +3,6 @@ from os import environ
 from re import sub
 from sys import argv
 
-import imghdr
 import smtplib
 
 sender_mail = environ['SENDER_MAIL']
@@ -27,7 +26,7 @@ def add_image(msg: EmailMessage, file_name):
     try:
         with open(file_name, 'rb') as f:
             img_data = f.read()
-            img_type = imghdr.what(f.name)  # TODO: Find alternative way to get an image's filetype
+            img_type = f.name.split('.')[-1]
             img_name = f.name
 
             msg.add_attachment(img_data, maintype='image', subtype=img_type, filename=img_name)


### PR DESCRIPTION
Script now uses builtin Python split() method to find an file's type